### PR TITLE
TITANIC: consolidate max saved game const and allow last saved to be loaded

### DIFF
--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -444,7 +444,8 @@ bool GraphicsManager::loadHSI(Common::SeekableReadStream *stream, int x, int y, 
 	}
 
 	// copy surface loaded to backdrop
-	_backdropSurface.copyRectToSurface(tmp.getPixels(), tmp.pitch, x, y, tmp.w, tmp.h);
+	Graphics::TransparentSurface tmp_trans(tmp, false);
+	tmp_trans.blit(_backdropSurface, x, y);
 	tmp.free();
 
 	_origBackdropSurface.copyFrom(_backdropSurface);

--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -224,6 +224,8 @@ bool GraphicsManager::reserveBackdrop() {
 	_vm->_evtMan->mouseX() = (int)((float)_vm->_evtMan->mouseX() / _cameraZoom);
 	_vm->_evtMan->mouseY() = (int)((float)_vm->_evtMan->mouseY() / _cameraZoom);
 
+	_backdropSurface.create(_sceneWidth, _sceneHeight, *_vm->getScreenPixelFormat());
+
 	return true;
 }
 

--- a/engines/sludge/builtin.cpp
+++ b/engines/sludge/builtin.cpp
@@ -977,11 +977,9 @@ builtIn(callEvent) {
 	return BR_CONTINUE;
 }
 
-bool reallyWantToQuit = false;
-
 builtIn(quitGame) {
 	UNUSEDALL
-	reallyWantToQuit = true;
+	g_sludge->_evtMan->quitGame();
 	return BR_CONTINUE;
 }
 

--- a/engines/sludge/event.cpp
+++ b/engines/sludge/event.cpp
@@ -43,6 +43,7 @@ EventManager::EventManager(SludgeEngine *vm) {
 	_vm = vm;
 
 	_weAreDoneSoQuit = 0;
+	_reallyWantToQuit = false;
 
 	_input.leftClick = _input.rightClick = _input.justMoved = _input.leftRelease = _input.rightRelease = false;
 	_input.keyPressed = 0;
@@ -129,7 +130,7 @@ void EventManager::checkInput() {
 
 			case Common::EVENT_QUIT:
 				_weAreDoneSoQuit = 1;
-				// TODO: if reallyWantToQuit, popup a message box to confirm
+				// TODO: if _reallyWantToQuit, popup a message box to confirm
 				break;
 
 			default:

--- a/engines/sludge/event.h
+++ b/engines/sludge/event.h
@@ -73,6 +73,7 @@ public:
 	void restore(FrozenStuffStruct *frozenStuff);
 
 	// Quit
+	void quitGame() { _weAreDoneSoQuit = true; /* _reallyWantToQuit = true; */ }
 	bool quit() { return _weAreDoneSoQuit; }
 
 private:
@@ -80,6 +81,7 @@ private:
 	InputType _input;
 
 	int _weAreDoneSoQuit;
+	bool _reallyWantToQuit;
 
 	EventHandlers *_currentEvents;
 };

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -250,7 +250,7 @@ bool PNGDecoder::loadStream(Common::SeekableReadStream &stream) {
 bool writePNG(Common::WriteStream &out, const Graphics::Surface &input, const bool bottomUp) {
 #ifdef USE_PNG
 	const Graphics::PixelFormat requiredFormat_3byte(3, 8, 8, 8, 0, 16, 8, 0, 0);
-	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 16, 8, 0, 24);
+	const Graphics::PixelFormat requiredFormat_4byte(4, 8, 8, 8, 8, 0, 8, 16, 24);
 
 	if (input.format.bytesPerPixel == 3) {
 		if (input.format != requiredFormat_3byte) {


### PR DESCRIPTION
Before titanic couldn't load the last save, or show its name in the GMM once saved. Now it can.

I also made the different files use the same const instead of defining their own.

Now if it is desirable to have more saved games it can just be changed in titanic.h and it works everywhere else.

Resolves #10051